### PR TITLE
Update haktldextract.go

### DIFF
--- a/haktldextract.go
+++ b/haktldextract.go
@@ -10,6 +10,11 @@ import (
 	"github.com/hakluke/tldextract"
 )
 
+var (
+	domainMap = make(map[string]bool) // this map will keep track of unique domains
+	domainMapMutex = &sync.Mutex{} // this mutex will make sure that reading and writing to the map is thread-safe
+)
+
 func main() {
 	concurrencyPtr := flag.Int("t", 8, "Number of threads to utilise. Default is 8.")
 	subdomainsPtr := flag.Bool("s", false, "dump subdomains instead of base domains")
@@ -43,11 +48,20 @@ func main() {
 func doWork(work chan string, wg *sync.WaitGroup, subdomainsPtr bool, extract *tldextract.TLDExtract) {
 	for url := range work {
 		result := extract.Extract(url)
+		var domain string
 		if subdomainsPtr && len(result.Sub) > 0 {
-			fmt.Println(result.Sub + "." + result.Root + "." + result.Tld)
+			domain = result.Sub + "." + result.Root + "." + result.Tld
 		} else {
-			fmt.Println(result.Root + "." + result.Tld)
+			domain = result.Root + "." + result.Tld
 		}
+		// lock the mutex to prevent concurrent read/write
+		domainMapMutex.Lock()
+		if _, ok := domainMap[domain]; !ok { // check if the domain is already in the map
+			domainMap[domain] = true 
+			fmt.Println(domain) // print the domain
+		}
+		// unlock the mutex
+		domainMapMutex.Unlock()
 	}
 	wg.Done()
 }


### PR DESCRIPTION
* Added support for eliminating duplicate domains within the Go tool, reducing the need for additional utilities like sort or uniq.

* Modified the doWork function to insert domains into a sync.Map instead of directly printing to stdout.

* Added a separate function to handle printing to stdout after all goroutines finish their work. This function iterates over the sync.Map, effectively printing only unique domains.

* Modified the program flow to wait until all goroutines finish their work before printing unique domains to stdout.